### PR TITLE
Update IIFE to reference window directly

### DIFF
--- a/requestanimationframe.js
+++ b/requestanimationframe.js
@@ -46,4 +46,4 @@ window.requestAnimationFrame || function (window) {
            window.clearTimeout(id);
        };
 
-}(this);
+}(window);


### PR DESCRIPTION
When using this polyfill as an ES2015 module (with a tool such as Rollup), it receives this error:

```
node_modules\window.requestanimationframe\requestanimationframe.js (49:2) The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten
```

This resolves the code to work as intended.

See https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined for more details